### PR TITLE
Support DOIs ending in punctuation

### DIFF
--- a/lib/doi.js
+++ b/lib/doi.js
@@ -1,12 +1,34 @@
 "use strict";
 
+const PATTERN = "\\b10\\.(?:97[89]\\.\\d{2,8}\\/\\d{1,7}|\\d{4,9}\\/\\S+)";
+const GLOBAL_PATTERN = new RegExp(PATTERN, "g");
+const SINGLE_PATTERN = new RegExp(PATTERN);
+const VALID_ENDING = /(?:\w|\(.+\)|2-#)$/;
+
 function extract(str) {
-    const matches = str.match(/\b10\.(?:97[89]\.\d{2,8}\/\d{1,7}|\d{4,9}\/\S+)\b/g);
+    const matches = String(str).toLowerCase().match(GLOBAL_PATTERN);
     if (!matches) {
         return [];
     }
 
-    return matches.map((doi) => doi.toLowerCase());
+    return matches.map(stripPunctuation).filter(Boolean);
+}
+
+function extractOne(str) {
+    const match = String(str).toLowerCase().match(SINGLE_PATTERN);
+    if (!match) {
+        return;
+    }
+
+    return stripPunctuation(match[0]);
+}
+
+function stripPunctuation(doi) {
+    if (VALID_ENDING.test(doi)) {
+        return doi;
+    }
+
+    return extractOne(doi.replace(/\W$/, ""));
 }
 
 exports.extract = extract;

--- a/tests/doi.test.js
+++ b/tests/doi.test.js
@@ -31,10 +31,50 @@ test("extracts DOIs with 9-digit prefixes", () => {
     expect(doi.extract("10.123456789/foobar")).toEqual(["10.123456789/foobar"]);
 });
 
-test("extract DOIs with punctuation in the suffix", () => {
+test("extracts DOIs with punctuation in the suffix", () => {
     expect(doi.extract("10.1234/foo.bar")).toEqual(["10.1234/foo.bar"]);
 });
 
-test("extract DOIs without trailing punctuation", () => {
+test("extracts DOIs without trailing punctuation", () => {
     expect(doi.extract("10.1234/foo.bar.")).toEqual(["10.1234/foo.bar"]);
+});
+
+test("extract DOIs ending with balanced parentheses", () => {
+    expect(doi.extract("10.1234/foo(bar)")).toEqual(["10.1234/foo(bar)"]);
+});
+
+test("discards multiple contiguous trailing punctuation", () => {
+    expect(doi.extract("10.1130/2013.2502...',")).toEqual(["10.1130/2013.2502"]);
+});
+
+test("discards trailing Unicode punctuation", () => {
+    expect(doi.extract("10.1130/2013.2502…")).toEqual(["10.1130/2013.2502"]);
+});
+
+test("extracts old Wiley DOIs", () => {
+    expect(doi.extract("10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#")).toEqual(["10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#"]);
+});
+
+test("does not extract a closing parenthesis if not part of the DOI", () => {
+    expect(doi.extract("(This is an example of a DOI: 10.1130/2013.2502)")).toEqual(["10.1130/2013.2502"]);
+});
+
+test("discards trailing punctuation from old Wiley DOIs", () => {
+    expect(doi.extract("10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#',")).toEqual(["10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#"]);
+});
+
+test("discards trailing punctuation after balanced parentheses", () => {
+    expect(doi.extract("10.1130/2013.2502(04)',")).toEqual(["10.1130/2013.2502(04)"]);
+});
+
+test("does not extract DOIs with purely punctuation suffixes", () => {
+    expect(doi.extract("10.1130/!).',")).toEqual([]);
+});
+
+test("extracts DOIs separated by Unicode whitespace", () => {
+    expect(doi.extract("10.1234/foo  10.1234/bar")).toEqual(["10.1234/foo", "10.1234/bar"]);
+});
+
+test("returns no DOIs if given nothing", () => {
+    expect(doi.extract(undefined)).toEqual([]);
 });


### PR DESCRIPTION
During some internal data clean-up work at @altmetric, we discovered DOIs that end with closing parentheses. These were being dropped by our extraction regular expression as we enforce a word boundary (which splits when a word character is followed by a non-word character such as a closing parenthesis).

By removing the strict word boundary, we can now pick up these closing parentheses and filter out any unwanted trailing punctuation in a second pass over the matches.

This means that we can successfully extract valid DOIs such as 10.1002/0471221929.ch26(v) but not invalid ones such as 10.1007/978-3-319-12580-0).