### PR TITLE
Fix ReDoS vulnerability in VALID_ENDING regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/doi.js
+++ b/src/doi.js
@@ -3,7 +3,7 @@
 const PATTERN = "\\b10\\.(?:97[89]\\.\\d{2,8}\\/\\d{1,7}|\\d{4,9}\\/\\S+)";
 const GLOBAL_PATTERN = new RegExp(PATTERN, "g");
 const SINGLE_PATTERN = new RegExp(PATTERN);
-const VALID_ENDING = /(?:\w|\(.+\)|2-#)$/;
+const VALID_ENDING = /(?:\w|\([^)]+\)|2-#)$/;
 
 function extract(str) {
     const matches = String(str).toLowerCase().match(GLOBAL_PATTERN);


### PR DESCRIPTION
Fixes https://github.com/altmetric/identifiers-doi/security/code-scanning/1

Change `.+` to `[^)]+` to prevent polynomial backtracking on malicious input
with many opening parentheses.

Bonus: Add explicit permissions to CI workflow (contents: read).